### PR TITLE
Dependencies adjusted for MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{include = "llm_playground"}]
 [tool.poetry.dependencies]
 python = "^3.10"
 openai = "^0.28.1"
-langchain = {extras = ["all"], version = "^0.0.306"}
+langchain = "^0.0.306"
 sparqlwrapper = "^2.0.0"
 fastapi = "^0.104.1"
 uvicorn = "^0.23.2"


### PR DESCRIPTION
@michaldatali can you check if this works on whatever env you are as well? Works on MacOS that way, with `all` it fails.